### PR TITLE
Add subscription purchase pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,8 @@ import Dashboard from './components/Dashboard';
 import FlashcardSetForm from './components/FlashcardSetForm';
 import FlashcardViewer from './components/FlashcardViewer';
 import PrivateRoute from './components/PrivateRoute';
+import SubscribePage from './components/SubscribePage';
+import SubscribeSuccess from './components/SubscribeSuccess';
 import { AuthProvider } from './context/AuthContext';
 import { SetsProvider } from './context/SetsContext';
 
@@ -57,6 +59,8 @@ function App() {
                 </PrivateRoute>
               }
             />
+            <Route path="/subscribe" element={<SubscribePage />} />
+            <Route path="/subscribe-success" element={<SubscribeSuccess />} />
           </Routes>
         </SetsProvider>
       </AuthProvider>

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -17,6 +17,11 @@ const Dashboard = () => {
         <h1 className="text-xl font-bold">Welcome {user.email}</h1>
         <button className="text-blue-500" onClick={() => { logout(); navigate('/'); }}>Log Out</button>
       </div>
+      {user.isMember ? (
+        <p className="mb-4 text-green-400">Premium Member</p>
+      ) : (
+        <Link className="underline" to="/subscribe">Become a Member</Link>
+      )}
       <Link className="underline" to="/create">Create New Set</Link>
       <h2 className="mt-4 font-semibold">My Sets</h2>
       <ul className="mb-4">

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { AiOutlineClose, AiOutlineMenu } from 'react-icons/ai';
 import Logo from '../assets/Logo.png';
 
@@ -27,6 +28,9 @@ const Navbar = () => {
         <li className='p-4 hover:text-gray-400'>
           <a href="#contact" onClick={() => handleLinkClick('contact')}>Contact</a>
         </li>
+        <li className='p-4 hover:text-gray-400'>
+          <Link to="/subscribe">Subscribe</Link>
+        </li>
       </ul>
       <div onClick={handleNav} className='block md:hidden z-20'>
         {nav ? <AiOutlineClose size={20}/> : <AiOutlineMenu size={20} />}
@@ -44,6 +48,9 @@ const Navbar = () => {
         </li>
         <li className='p-4 hover:text-gray-400'>
           <a href="#contact" onClick={() => handleLinkClick('contact')}>Contact</a>
+        </li>
+        <li className='p-4 hover:text-gray-400'>
+          <Link to="/subscribe" onClick={() => setNav(false)}>Subscribe</Link>
         </li>
       </ul>
     </div>

--- a/src/components/SubscribePage.jsx
+++ b/src/components/SubscribePage.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const SubscribePage = () => {
+  // Replace these with your real Stripe payment link URLs
+  const monthlyUrl = 'https://buy.stripe.com/test_monthly';
+  const yearlyUrl = 'https://buy.stripe.com/test_yearly';
+  const navigate = useNavigate();
+
+  const handleCheckout = (url) => {
+    window.location.href = url;
+  };
+
+  return (
+    <div className="flex flex-col items-center py-16 text-white px-4">
+      <h1 className="text-3xl font-bold mb-6">Choose Your Subscription</h1>
+      <div className="space-y-4 w-full max-w-sm">
+        <button
+          className="bg-[#00df9a] text-black rounded-md font-medium w-full px-6 py-3"
+          onClick={() => handleCheckout(monthlyUrl)}
+        >
+          Monthly - $4.99
+        </button>
+        <button
+          className="bg-[#00df9a] text-black rounded-md font-medium w-full px-6 py-3"
+          onClick={() => handleCheckout(yearlyUrl)}
+        >
+          Annually - $39.99
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default SubscribePage;

--- a/src/components/SubscribeSuccess.jsx
+++ b/src/components/SubscribeSuccess.jsx
@@ -1,0 +1,20 @@
+import React, { useEffect } from 'react';
+import { useAuth } from '../context/AuthContext';
+
+const SubscribeSuccess = () => {
+  const { updateMembership } = useAuth();
+
+  useEffect(() => {
+    // Mark the current user as a member
+    updateMembership();
+  }, [updateMembership]);
+
+  return (
+    <div className="flex flex-col items-center py-16 text-white px-4">
+      <h1 className="text-3xl font-bold mb-4">Thank you for subscribing!</h1>
+      <p>Your membership is now active.</p>
+    </div>
+  );
+};
+
+export default SubscribeSuccess;

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -22,9 +22,9 @@ export const AuthProvider = ({ children }) => {
   const signup = (email, password) => {
     const users = JSON.parse(localStorage.getItem(USERS_KEY) || '{}');
     if (users[email]) throw new Error('User already exists');
-    users[email] = { email, password };
+    users[email] = { email, password, isMember: false };
     localStorage.setItem(USERS_KEY, JSON.stringify(users));
-    setUser({ email });
+    setUser({ email, isMember: false });
   };
 
   const login = (email, password) => {
@@ -32,13 +32,27 @@ export const AuthProvider = ({ children }) => {
     if (!users[email] || users[email].password !== password) {
       throw new Error('Invalid credentials');
     }
-    setUser({ email });
+    const { isMember = false } = users[email];
+    setUser({ email, isMember });
   };
 
   const logout = () => setUser(null);
 
+  const updateMembership = () => {
+    setUser((u) => {
+      if (!u) return u;
+      const updated = { ...u, isMember: true };
+      const users = JSON.parse(localStorage.getItem(USERS_KEY) || '{}');
+      if (users[u.email]) {
+        users[u.email].isMember = true;
+        localStorage.setItem(USERS_KEY, JSON.stringify(users));
+      }
+      return updated;
+    });
+  };
+
   return (
-    <AuthContext.Provider value={{ user, signup, login, logout }}>
+    <AuthContext.Provider value={{ user, signup, login, logout, updateMembership }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- add Stripe subscription pages
- update navbar to link to the new pages
- show membership status on dashboard
- persist membership in `AuthContext`

## Testing
- `npm test --silent -- -w=0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850e26839d08327ac38aa2b390dfbca